### PR TITLE
Przywrocenie obsługi jsonów podczas attach'a

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 nbproject
 /vendor
 composer.lock
+/.idea
 
 tests/_output/*
 # Elastic Beanstalk Files

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.5.0",
         "desarrolla2/cache": "^2.0.0",
         "jasny/validation-result": "^1.0.0",
-        "guzzlehttp/guzzle": "^6.3"
+        "guzzlehttp/guzzle": "5.3.2"
     },
     "require-dev": {
         "codeception/codeception": "^2.1.0",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.5.0",
         "desarrolla2/cache": "^2.0.0",
         "jasny/validation-result": "^1.0.0",
-        "guzzlehttp/guzzle": "5.3.2"
+        "guzzlehttp/guzzle": "^5.3.2"
     },
     "require-dev": {
         "codeception/codeception": "^2.1.0",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "jasny/sso",
+    "name": "goldenline/sso",
     "description": "Simple Single Sign-On",
     "keywords": ["sso", "auth"],
     "license": "MIT",

--- a/examples/server/index.php
+++ b/examples/server/index.php
@@ -2,6 +2,7 @@
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 require_once 'MySSOServer.php';
+require_once __DIR__ . '/../../src/Polyfill/getallheaders.php';
 
 $ssoServer = new MySSOServer();
 $command = isset($_REQUEST['command']) ? $_REQUEST['command'] : null;

--- a/src/Broker.php
+++ b/src/Broker.php
@@ -140,7 +140,7 @@ class Broker implements BrokerInterface
     /**
      *{@inheritdoc}
      */
-    public function attach($returnUrl = null)
+    public function attach($returnUrl)
     {
         if ($this->isAttached()) return;
 

--- a/src/Broker.php
+++ b/src/Broker.php
@@ -160,7 +160,6 @@ class Broker
         $url = $this->getAttachUrl($params);
 
         header("Location: $url", true, 307);
-        echo "You're redirected to <a href='$url'>$url</a>";
         exit();
     }
 

--- a/src/BrokerInterface.php
+++ b/src/BrokerInterface.php
@@ -35,7 +35,7 @@ interface BrokerInterface
      *
      * @param string|true $returnUrl  The URL the client should be returned to after attaching
      */
-    public function attach($returnUrl = null);
+    public function attach($returnUrl);
 
     /**
      * Log the client in at the SSO server.

--- a/src/Polyfill/getallheaders.php
+++ b/src/Polyfill/getallheaders.php
@@ -1,0 +1,13 @@
+<?php
+
+if (!function_exists('getallheaders')) {
+    function getallheaders() {
+        $headers = [];
+        foreach ($_SERVER as $name => $value) {
+            if (substr($name, 0, 5) == 'HTTP_') {
+                $headers[str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))))] = $value;
+            }
+        }
+        return $headers;
+    }
+}

--- a/src/Server.php
+++ b/src/Server.php
@@ -221,7 +221,6 @@ abstract class Server
 
         $this->cache->set($sid, $this->getSessionData('id'));
         $this->outputAttachSuccess();
-        exit();
     }
 
     /**

--- a/src/Server.php
+++ b/src/Server.php
@@ -189,11 +189,12 @@ abstract class Server
      */
     protected function detectReturnType()
     {
-        if (true === empty($_GET['return_url'])) {
-            throw new \Exception('Return url cannot be empty', 400);
+        if (array_key_exists('return_url', $_GET) && false === empty($_GET['return_url'])) {
+            $this->returnType = 'redirect';
+        } else {
+            $this->returnType = 'json';
         }
 
-        $this->returnType = 'redirect';
     }
 
     /**
@@ -229,8 +230,17 @@ abstract class Server
      */
     protected function outputAttachSuccess()
     {
-        $url = $_REQUEST['return_url'];
-        header("Location: $url", true, 307);
+        if ($this->returnType === 'json') {
+            header('Content-type: application/json; charset=UTF-8');
+            echo json_encode(['success' => 'attached']);
+            exit;
+        }
+
+        if ($this->returnType === 'redirect') {
+            $url = $_REQUEST['return_url'];
+            header("Location: $url", true, 307);
+            exit;
+        }
     }
 
     /**

--- a/src/Server.php
+++ b/src/Server.php
@@ -221,6 +221,7 @@ abstract class Server
 
         $this->cache->set($sid, $this->getSessionData('id'));
         $this->outputAttachSuccess();
+        exit();
     }
 
     /**

--- a/src/Server.php
+++ b/src/Server.php
@@ -245,7 +245,6 @@ abstract class Server
         if ($this->returnType === 'redirect') {
             $url = $_REQUEST['return_url'];
             header("Location: $url", true, 307);
-            echo "You're being redirected to <a href='{$url}'>$url</a>";
         }
     }
 
@@ -365,7 +364,6 @@ abstract class Server
         if ($this->returnType === 'redirect') {
             $url = $_REQUEST['return_url'] . '?sso_error=' . $message;
             header("Location: $url", true, 307);
-            echo "You're being redirected to <a href='{$url}'>$url</a>";
             exit();
         }
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -129,7 +129,7 @@ abstract class Server
         $matches = null;
 
         if (!preg_match('/^SSO-(\w*+)-(\w*+)-([a-z0-9]*+)$/', $this->getBrokerSessionID(), $matches)) {
-            throw new \Exception("Invalid session id");
+            throw new \Exception("Invalid session id", 400);
         }
 
         $brokerId = $matches[1];
@@ -190,7 +190,7 @@ abstract class Server
     protected function detectReturnType()
     {
         if (true === empty($_GET['return_url'])) {
-            throw new \Exception('Return url cannot be empty');
+            throw new \Exception('Return url cannot be empty', 400);
         }
 
         $this->returnType = 'redirect';
@@ -232,18 +232,6 @@ abstract class Server
         $url = $_REQUEST['return_url'];
         header("Location: $url", true, 307);
     }
-
-    /**
-     * Output a 1x1px transparent image
-     */
-    protected function outputImage()
-    {
-        header('Content-Type: image/png');
-        echo base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQ'
-            . 'MAAAAl21bKAAAAA1BMVEUAAACnej3aAAAAAXRSTlMAQObYZg'
-            . 'AAAApJREFUCNdjYAAAAAIAAeIhvDMAAAAASUVORK5CYII=');
-    }
-
 
     /**
      * Authenticate

--- a/src/Server.php
+++ b/src/Server.php
@@ -4,6 +4,7 @@ namespace Jasny\SSO;
 use Desarrolla2\Cache\Cache;
 use Desarrolla2\Cache\Adapter;
 
+require_once __DIR__ . '/../src/Polyfill/getallheaders.php';
 /**
  * Single sign-on server.
  *
@@ -309,6 +310,7 @@ abstract class Server
 
         header('Content-type: application/json; charset=UTF-8');
         echo json_encode($user);
+        exit();
     }
 
 

--- a/src/ServerAwareBroker.php
+++ b/src/ServerAwareBroker.php
@@ -73,7 +73,8 @@ class ServerAwareBroker implements BrokerInterface
     public function attach($returnUrl = null)
     {
         //check if the server is alive
-        $this->client->request('GET', $this->healthCheckUrl);
+        $request = $this->client->createRequest('GET', $this->healthCheckUrl);
+        $this->client->send($request);
 
         $this->broker->attach($returnUrl);
     }

--- a/src/ServerAwareBroker.php
+++ b/src/ServerAwareBroker.php
@@ -72,6 +72,10 @@ class ServerAwareBroker implements BrokerInterface
      */
     public function attach($returnUrl = null)
     {
+        if ($this->broker->isAttached()) {
+            return;
+        }
+
         //check if the server is alive
         $request = $this->client->createRequest('GET', $this->healthCheckUrl);
         $this->client->send($request);


### PR DESCRIPTION
CEL
---
Jeśli podczas `attach` nie ma `return_url`, przy sukcesie zwracamy json `{"success":"attached"}`

TODO
---
- [x] przywrócenie wyrzuconych kroków